### PR TITLE
Fix relative import for CLI module execution

### DIFF
--- a/extractor/cli.py
+++ b/extractor/cli.py
@@ -51,7 +51,6 @@ def main():
 
     rows = []
     if args.backend == "pymupdf4llm":
-        from backends.pymupdf4llm_backend import extract_markdown_pages
         md_pages = list(extract_markdown_pages(input_path))
         LOGGER.info("Conversion complete via PyMuPDF. Pages: %d", len(md_pages))
 


### PR DESCRIPTION
## Summary
- remove the redundant local import of the PyMuPDF backend so the CLI works when executed as a module

## Testing
- not run (PyMuPDF dependency not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e3e764acd08332bf7260d50269cd2f