### PR TITLE
Add shared text cleaning utilities and apply during parsing

### DIFF
--- a/extractor/text_clean.py
+++ b/extractor/text_clean.py
@@ -1,0 +1,65 @@
+import html
+import re
+import unicodedata
+
+# precompile small regex set
+MULTISPACE_RE = re.compile(r"[ \t]{2,}")
+NBSP_RE       = re.compile(r"\u00A0")         # non-breaking space
+CTRL_RE       = re.compile(r"[\u0000-\u001F\u007F]")
+DUP_EN_RE     = re.compile(r"^(?P<a>.+?)\s+\1$", re.IGNORECASE)  # "abc abc" -> "abc"
+# common bilingual prefix pattern: non-Latin block then the English
+NON_LATIN_PREFIX_RE = re.compile(r"^(?P<nonlatin>[^\x00-\x7F]{2,}[\s:|-/]+)(?P<latin>[A-Za-z].+)$")
+# stray pipes from markdown tables when one cell leaks
+LEADING_PIPE_RE = re.compile(r"^\s*\|\s*")
+TRAILING_PIPE_RE = re.compile(r"\s*\|\s*$")
+
+
+def _strip_bilingual_prefix(s: str) -> str:
+    """
+    If line begins with a non-Latin chunk followed by the same English phrase,
+    prefer the English portion. Example:
+      'CEO 메시지 Message from the CEO' -> 'Message from the CEO'
+    """
+    m = NON_LATIN_PREFIX_RE.match(s)
+    if not m:
+        return s
+    latin = m.group("latin").strip()
+
+    # If the latin part repeats tokens from the tail or contains clear English words,
+    # keep it; otherwise keep original.
+    if any(tok in latin.lower() for tok in ("message", "report", "sustainability", "ceo", "target", "governance")):
+        return latin
+    return s
+
+
+def clean_text(s: str) -> str:
+    if s is None:
+        return ""
+
+    # 1) HTML entity decode (&amp; -> &, &nbsp; -> space)
+    s = html.unescape(s)
+
+    # 2) Unicode normalization (folds weird diacritics/widths)
+    s = unicodedata.normalize("NFKC", s)
+
+    # 3) Remove control chars, normalize spaces
+    s = CTRL_RE.sub(" ", s)
+    s = NBSP_RE.sub(" ", s)
+
+    # 4) Drop leading/trailing table pipes that sometimes slip into single cells
+    s = LEADING_PIPE_RE.sub("", s)
+    s = TRAILING_PIPE_RE.sub("", s)
+
+    # 5) Trim, collapse multi-spaces
+    s = s.strip()
+    s = MULTISPACE_RE.sub(" ", s)
+
+    # 6) Bilingual prefix cleanup (non-Latin then English)
+    s = _strip_bilingual_prefix(s)
+
+    # 7) Simple duplicate phrase collapse: "abc abc" -> "abc"
+    m = DUP_EN_RE.match(s)
+    if m:
+        s = m.group("a")
+
+    return s.strip()

--- a/tools/clean_xlsx.py
+++ b/tools/clean_xlsx.py
@@ -1,0 +1,33 @@
+import argparse
+
+import pandas as pd
+
+from extractor.text_clean import clean_text
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="input_xlsx", required=True)
+    ap.add_argument("--out", dest="out_xlsx", required=True)
+    args = ap.parse_args()
+
+    df = pd.read_excel(args.input_xlsx)
+    if "text" in df.columns:
+        df["text"] = df["text"].astype(str).map(clean_text)
+    if "current_section" in df.columns:
+        df["current_section"] = df["current_section"].astype(str).map(clean_text)
+    if "h1" in df.columns:
+        df["h1"] = df["h1"].astype(str).map(clean_text)
+    if "h2" in df.columns:
+        df["h2"] = df["h2"].astype(str).map(clean_text)
+    if "h3" in df.columns:
+        df["h3"] = df["h3"].astype(str).map(clean_text)
+    if "section_path" in df.columns:
+        df["section_path"] = df["section_path"].astype(str).map(clean_text)
+
+    df.to_excel(args.out_xlsx, index=False)
+    print(f"Cleaned -> {args.out_xlsx} (rows={len(df)})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a reusable text_clean module that normalizes entities, whitespace, and bilingual prefixes
- apply the cleaner across markdown parsing outputs for headings, bullets, tables, and sentences
- add a tool to re-clean previously exported Excel files using the shared cleaner

## Testing
- No automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e41b09b7f08332ae26414186463df5